### PR TITLE
forgot to add a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p>To run the program, use the following commands:</p> <ul> <li><strong>Windows:</strong> <code>py app.py</code></li> <li><strong>Linux:</strong> <code>python3 app.py</code></li> </ul>
 
 <h2>Available Commands</h2>
-<p>The program supports the following commands:</p> <ul> <li><code>add &lt;name&gt;</code>: Add a new task with the given name.</li> <li><code>update &lt;id&gt; &lt;new_desc&gt;</code>: Update the description of the task with the given ID.</li> <li><code>remove &lt;id&gt;</code>: Remove the task with the given ID.</li> <li><code>mark_done &lt;id&gt;</code>: Mark the task with the given ID as done.</li> <li><code>mark_in_progress &lt;id&gt;</code>: Mark the task with the given ID as in progress.</li> <li><code>list</code>: Show all tasks. You can also filter tasks by status by using the <code>done</code> or <code>to-do</code> argument.</li> </ul>
+<p>The program supports the following commands:</p> <ul> <li><code>add &lt;name&gt;</code>: Add a new task with the given name.</li> <li><code>update &lt;id&gt; &lt;new_desc&gt;</code>: Update the description of the task with the given ID.</li> <li><code>remove &lt;id&gt;</code>: Remove the task with the given ID.</li> <li><code>mark_done &lt;id&gt;</code>: Mark the task with the given ID as done.</li> <li><code>mark_in_progress &lt;id&gt;</code>: Mark the task with the given ID as in progress.</li> <li><code>mark_to_do &lt;id&gt;</code>: Mark the task with the given ID as to-do.</li> <li><code>list</code>: Show all tasks. You can also filter tasks by status by using the <code>done</code> or <code>to-do</code> argument.</li> </ul>
 
 <h2>Examples</h2>
 <p>Here are some examples of how to use the program:</p> <ul> <li><code>add "Buy milk"</code>: Add a new task to buy milk.</li> <li><code>update 1 "Buy eggs"</code>: Update the description of the task with ID 1 to "Buy eggs".</li> <li><code>remove 2</code>: Remove the task with ID 2.</li> <li><code>mark_done 1</code>: Mark the task with ID 1 as done.</li> <li><code>list</code>: Show all tasks.</li> <li><code>list done</code>: Show only tasks that are marked as done.</li> <li><code>list to-do</code>: Show only tasks that are marked as to-do.</li> </ul>
@@ -15,4 +15,5 @@
 <p>This program has two versions available:</p> <ul> <li>One version uses only default <a href="https://www.python.org/">Python</a> libraries.</li> <li>One version uses the <a href="https://click.palletsprojects.com/">Click library</a> for building the CLI.</li> </ul>
 
 <h2>Note</h2>
-<p>Please make sure to use the correct version of the program according to your needs. If you have any issues or questions, feel free to ask.</p
+<p>Please make sure to use the correct version of the program according to your needs. If you have any issues or questions, feel free to ask.</p>
+<p style="text-style:bold">This project is made according to the cli project from <a href="https://roadmap.sh/projects/task-tracker">roadmap.sh</a></p>

--- a/app.py
+++ b/app.py
@@ -118,10 +118,15 @@ def update(id, description):
 def remove(id):
     click.echo(remove_task_by_id(id))
 
-@cli.command(help="Mark a task as 'to-do'.")
+@cli.command(help="Mark a task as 'in-progress'.")
 @click.argument('id', type=int)
 def mark_in_progress(id):
-    update_task_status(id, "in-progress")
+    update_task_status(id, "done")
+
+@cli.command(help="Mark a task as 'to-do'.")
+@click.argument('id', type=int)
+def mark_to_do(id):
+    update_task_status(id, "to-do")
 
 @cli.command(help="Mark a task as 'done'.")
 @click.argument('id', type=int)

--- a/tasks.json
+++ b/tasks.json
@@ -1,9 +1,1 @@
-[
-    {
-        "id": 1,
-        "description": "Crhistmass",
-        "status": "to-do",
-        "created_at": "2024-12-10",
-        "updated_at": "2024-12-10"
-    }
-]
+[]


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new CLI command 'mark_to_do' to allow users to mark tasks as 'to-do', and update the documentation to reflect this addition.

New Features:
- Add a new CLI command 'mark_to_do' to mark tasks as 'to-do'.

Documentation:
- Update README.md to include the new 'mark_to_do' command in the list of available commands.